### PR TITLE
docs: Community and reference material links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # cesrox
-Rust implementation of core CESR encoding format. A bridge to the beautiful island.
+Rust implementation of the core CESR encoding format according to the [IETF CESR Spec](https://github.com/WebOfTrust/ietf-cesr). A bridge to the beautiful island.
 
-# What is CESR?
+CESR stands for Composable Event Streaming Representation. It represents cryptographic primitives and any other data structure compactly and efficiently with a combined binary and text protocol.
+
+For a more complete definition of CESR refer to the following IETF draft spec:
+
+## What is CESR?
 https://weboftrust.github.io/ietf-cesr/draft-ssmith-cesr.html
 
 # Community
-
-Slack https://join.slack.com/t/keriworld/shared_invite/zt-14326yxue-p7P~GEmAZ65luGSZvbgFAQ ,  `#cesrox` channel.
+## Bi-weekly Meeting 
+- [Zoom Link](https://us06web.zoom.us/j/88102305873?pwd=Wm01TEJKUWc0aE51a0QzZ2hNbTV2Zz09)
+- [HackMD Link](https://hackmd.io/UQaEI0w8Thy_xRF7oYX03Q?view) Bi-Weekly Meeting Agenda and Minutes 
+- Slack https://join.slack.com/t/keriworld/shared_invite/zt-14326yxue-p7P~GEmAZ65luGSZvbgFAQ 
+  - `#cesrox` channel.
+  
+# Important Reference Material
+- WebOfTrust/[ietf-cesr](https://github.com/WebOfTrust/ietf-cesr) repository - IETF draft specification for CESR
+- Design Assumptions, Use Cases, and ToDo list - [HackMD link](https://hackmd.io/W2Z39cuSSTmD2TovVLvAPg?view)
+- Introductory articles: 
+  - [#1 CESR Proof Signatures](https://medium.com/happy-blockchains/cesr-proof-signatures-are-the-segwit-of-authentic-data-in-keri-e891c83e070a)
+  - [#2 CESR Overview](https://medium.com/happy-blockchains/cesr-one-of-sam-smiths-inventions-is-as-controversial-as-genius-d757f36b88f8)


### PR DESCRIPTION
I added links to many of the items we discussed in our meeting today including the Bi-weekly zoom link, the meeting agenda and minutes link, as well as the IETF Draft Spec for CESR and Henk's articles.