### PR TITLE
adds cargo fmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
 
       - uses: actions/checkout@v2
       - name: Build
-        run: cargo build --verbose
-
-      - name: Run tests
-        run: cargo test --verbose
+        run: | 
+          cargo build
+          cargo test
+          cargo fmt --all -- --check
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/src/derivation/basic.rs
+++ b/src/derivation/basic.rs
@@ -80,7 +80,6 @@ impl FromStr for Basic {
     }
 }
 
-
 #[cfg(test)]
 mod basic_tests {
     use crate::derivation::basic::Basic;

--- a/src/derivation/self_addressing.rs
+++ b/src/derivation/self_addressing.rs
@@ -174,10 +174,10 @@ fn sha2_512_digest(input: &[u8]) -> Vec<u8> {
 
 #[cfg(test)]
 mod self_addressing_tests {
-    use base64::URL_SAFE;
-    use std::str;
     use crate::derivation::self_addressing::SelfAddressing;
     use crate::prefix::Prefix;
+    use base64::URL_SAFE;
+    use std::str;
 
     #[test]
     fn test_self_addressing() {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -94,7 +94,6 @@ pub enum Error {
     //
     // #[error(transparent)]
     // SerdeSerError(#[from] serializer_error::Error),
-
     #[cfg(feature = "wallet")]
     #[error(transparent)]
     WalletError(#[from] universal_wallet::Error),

--- a/src/error/serializer_error.rs
+++ b/src/error/serializer_error.rs
@@ -4,7 +4,11 @@ use std::fmt::{self, Display, Formatter};
 use serde::{de, ser};
 
 use crate::derivation::basic::Basic;
-use crate::error::serializer_error::Error::{Eof, ExpectedArray, ExpectedArrayComma, ExpectedArrayEnd, ExpectedBoolean, ExpectedEnum, ExpectedInteger, ExpectedMap, ExpectedMapColon, ExpectedMapComma, ExpectedMapEnd, ExpectedNull, ExpectedString, Message, Syntax, TrailingCharacters};
+use crate::error::serializer_error::Error::{
+    Eof, ExpectedArray, ExpectedArrayComma, ExpectedArrayEnd, ExpectedBoolean, ExpectedEnum,
+    ExpectedInteger, ExpectedMap, ExpectedMapColon, ExpectedMapComma, ExpectedMapEnd, ExpectedNull,
+    ExpectedString, Message, Syntax, TrailingCharacters,
+};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -64,9 +68,7 @@ impl Display for Error {
             ExpectedString => formatter.write_str("incorrect input: expected string"),
             ExpectedNull => formatter.write_str("incorrect input: expected null"),
             ExpectedArray => formatter.write_str("incorrect input: expected array"),
-            ExpectedArrayComma => {
-                formatter.write_str("incorrect input: expected array comma")
-            }
+            ExpectedArrayComma => formatter.write_str("incorrect input: expected array comma"),
             ExpectedArrayEnd => formatter.write_str("incorrect input: expected array end"),
             ExpectedMap => formatter.write_str("incorrect input: expected map"),
             ExpectedMapColon => formatter.write_str("incorrect input: expected map colon"),
@@ -85,19 +87,55 @@ fn test_from_str() {
     assert_eq!(&format!("{}", Message("foo".to_string())), "foo");
     assert_eq!(&format!("{}", Eof), "unexpected end of input");
     assert_eq!(&format!("{}", Syntax), "incorrect syntax");
-    assert_eq!(&format!("{}", ExpectedBoolean), "incorrect input: expected boolean");
-    assert_eq!(&format!("{}", ExpectedInteger), "incorrect input: expected integer");
-    assert_eq!(&format!("{}", ExpectedString), "incorrect input: expected string");
-    assert_eq!(&format!("{}", ExpectedNull), "incorrect input: expected null");
-    assert_eq!(&format!("{}", ExpectedArray), "incorrect input: expected array");
-    assert_eq!(&format!("{}", ExpectedArrayComma), "incorrect input: expected array comma");
-    assert_eq!(&format!("{}", ExpectedArrayEnd), "incorrect input: expected array end");
+    assert_eq!(
+        &format!("{}", ExpectedBoolean),
+        "incorrect input: expected boolean"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedInteger),
+        "incorrect input: expected integer"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedString),
+        "incorrect input: expected string"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedNull),
+        "incorrect input: expected null"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedArray),
+        "incorrect input: expected array"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedArrayComma),
+        "incorrect input: expected array comma"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedArrayEnd),
+        "incorrect input: expected array end"
+    );
     assert_eq!(&format!("{}", ExpectedMap), "incorrect input: expected map");
-    assert_eq!(&format!("{}", ExpectedMapColon), "incorrect input: expected map colon");
-    assert_eq!(&format!("{}", ExpectedMapComma), "incorrect input: expected map comma");
-    assert_eq!(&format!("{}", ExpectedMapEnd), "incorrect input: expected map end");
-    assert_eq!(&format!("{}", ExpectedEnum), "incorrect input: expected enum");
-    assert_eq!(&format!("{}", TrailingCharacters), "incorrect input: unexpected trailing characters");
+    assert_eq!(
+        &format!("{}", ExpectedMapColon),
+        "incorrect input: expected map colon"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedMapComma),
+        "incorrect input: expected map comma"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedMapEnd),
+        "incorrect input: expected map end"
+    );
+    assert_eq!(
+        &format!("{}", ExpectedEnum),
+        "incorrect input: expected enum"
+    );
+    assert_eq!(
+        &format!("{}", TrailingCharacters),
+        "incorrect input: unexpected trailing characters"
+    );
 }
 
 impl std::error::Error for Error {}


### PR DESCRIPTION
Given we're seeing contributions from the community, I feel it is appropriate to standardize code formatting.

This can be done by:
`cargo fmt`

By default, Rustfmt uses a style which conforms to the [Rust style guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md) that has been formalized through the [style RFC process](https://github.com/rust-dev-tools/fmt-rfcs).